### PR TITLE
change url to redirect to github repository

### DIFF
--- a/patches/calamares-nixos-extensions/branding/nixos/branding.desc
+++ b/patches/calamares-nixos-extensions/branding/nixos/branding.desc
@@ -47,11 +47,11 @@ strings:
     versionedName:       GLF-OS
     shortVersionedName:  GLF-OS
     bootloaderEntryName: GLF-OS
-    productUrl:          https://nixos.org/
-    supportUrl:          https://nixos.org/manual/nixos
-    knownIssuesUrl:      https://github.com/NixOS/nixpkgs/issues
-    releaseNotesUrl:     https://nixos.org/manual/nixos/stable/release-notes.html
-    donateUrl:           https://nixos.org/donate.html
+    productUrl:          https://github.com/GLF-OS/Nixos-by-GLF
+    supportUrl:          https://github.com/GLF-OS/Nixos-by-GLF
+    knownIssuesUrl:      https://github.com/GLF-OS/Nixos-by-GLF/issues
+    releaseNotesUrl:     https://github.com/GLF-OS/Nixos-by-GLF/releases
+    donateUrl:           https://github.com/GLF-OS/Nixos-by-GLF
 
 images:
     # productBanner:       "banner.png"


### PR DESCRIPTION
Correction des url de l'installateur vers le projet glf. 

> [!INFO] 
> Les urls "manual" et "community" en fin d'installation n'ont pas (encore) été modifié.
> A l'avenir, nous devrions modifier l'url "product" vers le site (j'imagine)