### PR TITLE
Remove custom vm.max_map_count value because default value is enough

### DIFF
--- a/nix-cfg/glf/boot.nix
+++ b/nix-cfg/glf/boot.nix
@@ -9,7 +9,6 @@
     kernelPackages = pkgs.linuxPackages_zen;
     # kernelPackages = pkgs.linuxPackages_xanmod_latest;
 
-    kernel.sysctl = { "vm.max_map_count" = 2147483642; };
     kernelParams = if builtins.elem "kvm-amd" config.boot.kernelModules then [ "amd_pstate=active" ] else [ ];
   };
 }


### PR DESCRIPTION
Comme convenu sur discord, la valeur personnalisée `vm.max_map_count` est supprimé puisque celle fournie par défaut `1048576` est suffisante. 