### PR TITLE
Feature : make torrent file with makefile

### DIFF
--- a/patches/calamares-nixos-extensions/branding/nixos/branding.desc
+++ b/patches/calamares-nixos-extensions/branding/nixos/branding.desc
@@ -47,11 +47,11 @@ strings:
     versionedName:       GLF-OS
     shortVersionedName:  GLF-OS
     bootloaderEntryName: GLF-OS
-    productUrl:          https://nixos.org/
-    supportUrl:          https://nixos.org/manual/nixos
-    knownIssuesUrl:      https://github.com/NixOS/nixpkgs/issues
-    releaseNotesUrl:     https://nixos.org/manual/nixos/stable/release-notes.html
-    donateUrl:           https://nixos.org/donate.html
+    productUrl:          https://github.com/GLF-OS/Nixos-by-GLF
+    supportUrl:          https://github.com/GLF-OS/Nixos-by-GLF
+    knownIssuesUrl:      https://github.com/GLF-OS/Nixos-by-GLF/issues
+    releaseNotesUrl:     https://github.com/GLF-OS/Nixos-by-GLF/releases
+    donateUrl:           https://github.com/GLF-OS/Nixos-by-GLF
 
 images:
     # productBanner:       "banner.png"


### PR DESCRIPTION
- Le Makefile permet maintenant de générer un fichier torrent associé au tracker "opentrackr". 
- Suppression de l'argument `test` dans phony qui n'existe plus depuis son remplacement par `build` et `check`
- L'argument `all` utilisé pour `make all` inclut la génération du torrent. 
- Le fichier torrent résultant inclut l'iso et son checksum. 

Je note la présence d'un "bug" que je n'ai pas su corriger, rien de grave. 
Si l'utilisateur utilise `make install` `make torrent` ou `make all` avec un nom de branche git incluant un "/", il est interprété comme un chemin.. en bref ça ne fonctionne pas, il faut des noms de branche sans "/". 

Pour tester ce commit : 

> [!NOTE]
> Nécessite `gnumake` et `nix`

```bash
nix-shell -p gnumake --run "make all"
```

On s'attend à obtenir un répertoire iso : 

```bash
iso
├── glfos-24.11.20241202.f9f0d5c_coraal_featureGenerateTorrentIso.iso
├── glfos-24.11.20241202.f9f0d5c_coraal_featureGenerateTorrentIso.iso.sha256sum
└── glfos-24.11.20241202.f9f0d5c_coraal_featureGenerateTorrentIso.iso.torrent
```

