### PR TITLE
change branch for download latest glf module

### DIFF
--- a/nix-cfg/glf/updateConf.nix
+++ b/nix-cfg/glf/updateConf.nix
@@ -11,7 +11,7 @@ let
     REPO_URL="https://github.com/GLF-OS/Nixos-by-GLF.git"
 
     # Branche et chemin à extraire
-    BRANCH="dev"
+    BRANCH="main"
     SUBDIR="nix-cfg/glf"
 
     # Répertoire cible


### PR DESCRIPTION
Actuellement, le script qui récupère la dernière version du module GLF est basé sur la branche dev (nécessaire durant les tests puisque la branche main était... vide)