### PR TITLE
flake update, fix issue with printing not imported

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733550349,
-        "narHash": "sha256-NcGumB4Lr6KSDq+nIqXtNA8QwAQKDSZT7N9OTGWbTrs=",
+        "lastModified": 1734737257,
+        "narHash": "sha256-GIMyMt1pkkoXdCq9un859bX6YQZ/iYtukb9R5luazLM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2605d0744c2417b09f8bf850dfca42fcf537d34",
+        "rev": "1c6e20d41d6a9c1d737945962160e8571df55daa",
         "type": "github"
       },
       "original": {

--- a/nix-cfg/glf/default.nix
+++ b/nix-cfg/glf/default.nix
@@ -12,5 +12,6 @@
     ./nvidia.nix
     ./system.nix
     ./updateConf.nix
+    ./imprimante.nix
   ];
 }


### PR DESCRIPTION
- Import du module d'impression https://github.com/GLF-OS/Nixos-by-GLF/issues/82 
- Mis à jour du flocon pour https://github.com/GLF-OS/Nixos-by-GLF/pull/81 
 Il manquait l'update du flocon pour pointer sur le driver 565, en réalité nous étions sur une version précédente : 

```bash
       error: Package ‘nvidia-x11-560.35.03-6.12.1’ in /nix/store/sqmn1ky3k66661h32djyjvsr8l99330z-source/pkgs/os-specific/linux/nvidia-x11/generic.nix:278 is marked as broken, refusing to evaluate.

       a) To temporarily allow broken packages, you can use an environment variable
          for a single invocation of the nix tools.

            $ export NIXPKGS_ALLOW_BROKEN=1

          Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
                then pass `--impure` in order to allow use of environment variables.

       b) For `nixos-rebuild` you can set
         { nixpkgs.config.allowBroken = true; }
       in configuration.nix to override this.

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allowBroken = true; }
       to ~/.config/nixpkgs/config.nix.
make: *** [check] Error 1
```