### PR TITLE
Enable fractional scaling support in GNOME Mutter

### DIFF
--- a/nix-cfg/glf/gnome.nix
+++ b/nix-cfg/glf/gnome.nix
@@ -1,15 +1,25 @@
 { pkgs, lib, ... }:
 {
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  # Activation de Gnome
+  # Activation de GNOME
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   services = {
     udev.packages = [ pkgs.gnome-settings-daemon ];
     xserver = {
       displayManager.gdm.enable = lib.mkDefault true;
-      desktopManager.gnome.enable = lib.mkDefault true;
+      desktopManager.gnome = {
+        enable = lib.mkDefault true;
+
+        # Activation du Fractional Scaling
+        extraGSettingsOverridePackages = [ pkgs.mutter ];
+        extraGSettingsOverrides = ''
+          [org.gnome.mutter]
+          experimental-features=['scale-monitor-framebuffer']
+        '';
+      };
     };
   };
+
   documentation.nixos.enable = false;
 
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -20,7 +30,7 @@
     package = pkgs.gnomeExtensions.gsconnect;
   };
 
-  environment.systemPackages = with pkgs;[
+  environment.systemPackages = with pkgs; [
 
     # theme
     adw-gtk3
@@ -29,7 +39,6 @@
 
     # gnome
     gnome-tweaks
-    
 
     # Extension
     gnomeExtensions.caffeine
@@ -63,7 +72,7 @@
   ];
 
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  # Paramètre GNOME
+  # Paramètres GNOME
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   programs.dconf = {
     enable = true;


### PR DESCRIPTION
Enables fractional scaling by adding the experimental feature  'scale-monitor-framebuffer' to GNOME Mutter's configuration. 

Modified setting:
- org.gnome.mutter.experimental-features: ['scale-monitor-framebuffer']

![FS Gnome](https://github.com/user-attachments/assets/bcc53731-afd8-4792-9ef7-03edccf4f6a7)